### PR TITLE
Fix missing IP under internet device like ens* & enp*s*

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ set -e
 if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
   MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1 | sed 's|\(.*\)/.*|\1|g')
   if [ -z "$MON_IP" ]; then
-    MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 } | sed 's|\(.*\)/.*|\1|g'')
+    MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }' | sed 's|\(.*\)/.*|\1|g')
   fi
   if [ -z "$MON_IP" ]; then
     MON_IP=$(ip -4 -o a | awk '/en/ { sub ("/..", "", $4); print $4 }' | sed 's|\(.*\)/.*|\1|g')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,8 @@ if [ ! -n "$MON_IP" ]; then
    exit 1
 fi
 
+# Remove network mask
+MON_IP=$(echo $MONIP | sed 's|\(.*\)/.*|\1|g')
 
 if [ ! -e /etc/ceph/${CLUSTER}.conf ]; then
   ### Bootstrap the ceph cluster

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,9 @@ if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
   if [ -z "$MON_IP" ]; then
     MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
   fi
+  if [ -z "$MON_IP" ]; then
+    MON_IP=$(ip -4 -o a | awk '/en/ { sub ("/..", "", $4); print $4 }')
+  fi
 elif [ ${MON_IP_AUTO_DETECT} -eq 4 ]; then
   MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
 elif [ ${MON_IP_AUTO_DETECT} -eq 6 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,26 +11,23 @@ set -e
 #   docker run -e MON_IP=192.168.101.50 -e MON_IP_AUTO_DETECT=1 ceph/mon
 
 if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
-  MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)
+  MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1 | sed 's|\(.*\)/.*|\1|g')
   if [ -z "$MON_IP" ]; then
-    MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
+    MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 } | sed 's|\(.*\)/.*|\1|g'')
   fi
   if [ -z "$MON_IP" ]; then
-    MON_IP=$(ip -4 -o a | awk '/en/ { sub ("/..", "", $4); print $4 }')
+    MON_IP=$(ip -4 -o a | awk '/en/ { sub ("/..", "", $4); print $4 }' | sed 's|\(.*\)/.*|\1|g')
   fi
 elif [ ${MON_IP_AUTO_DETECT} -eq 4 ]; then
-  MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
+  MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }' | sed 's|\(.*\)/.*|\1|g')
 elif [ ${MON_IP_AUTO_DETECT} -eq 6 ]; then
-  MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)
+  MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1 | sed 's|\(.*\)/.*|\1|g')
 fi
 
 if [ ! -n "$MON_IP" ]; then
    echo "ERROR- MON_IP must be defined as the IP address of the monitor"
    exit 1
 fi
-
-# Remove network mask
-MON_IP=$(echo $MONIP | sed 's|\(.*\)/.*|\1|g')
 
 if [ ! -e /etc/ceph/${CLUSTER}.conf ]; then
   ### Bootstrap the ceph cluster


### PR DESCRIPTION
VM like this
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: **ens3**: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 06:85:50:00:2c:2e brd ff:ff:ff:ff:ff:ff
    inet 10.123.45.46/8 brd 10.255.255.255 scope global ens3
       valid_lft forever preferred_lft forever
    inet6 fe80::485:50ff:fe00:2c2e/64 scope link
       valid_lft forever preferred_lft forever